### PR TITLE
[rfc] upgrade to new version of kafka-avro-confluent

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,20 @@
 # kafka-clj-test-utils [![CircleCI](https://circleci.com/gh/ovotech/kafka-clj-test-utils/tree/master.svg?style=svg)](https://circleci.com/gh/ovotech/kafka-clj-test-utils/tree/master)
 
-Companion test utility library to make testing applications that use [ovotech/kafka-clj-utils](https://github.com/ovotech/kafka-clj-test-utils)
-easier, although it can be used on it's own.
+Companion test utility library to make testing applications that use
+[ovotech/kafka-clj-utils](https://github.com/ovotech/kafka-clj-test-utils)
+easier, although it can be used on its own.
 
 ## Usage
 
-[![Clojars Project](https://img.shields.io/clojars/v/ovotech/kafka-clj-test-utils.svg)](https://clojars.org/ovotech/kafka-clj-test-utils)
+[![Clojars
+Project](https://img.shields.io/clojars/v/ovotech/kafka-clj-test-utils.svg)](https://clojars.org/ovotech/kafka-clj-test-utils)
 
-For examples of how to use this library in the context of [ovotech/kafka-clj-utils](https://github.com/ovotech/kafka-clj-test-utils),
+For examples of how to use this library in the context of
+[ovotech/kafka-clj-utils](https://github.com/ovotech/kafka-clj-test-utils),
 please view tests in that code base.
 
-For examples of how to use this library **without** [ovotech/kafka-clj-utils](https://github.com/ovotech/kafka-clj-test-utils),
+For examples of how to use this library **without**
+[ovotech/kafka-clj-utils](https://github.com/ovotech/kafka-clj-test-utils),
 please view `test/kafka_clj_test_utils/utils_test.clj`.
 
 

--- a/dev/resources/logback-test.xml
+++ b/dev/resources/logback-test.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%date{ISO8601} %-5level[%thread] %logger %X{} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="org.apache.kafka" level="WARN" />
+    <logger name="org.apache.zookeeper" level="WARN" />
+    <logger name="org.apache.curator" level="WARN" />
+    <logger name="org.hibernate" level="WARN" />
+    <logger name="kafka" level="WARN" />
+    <logger name="io.confluent" level="WARN" />
+    <logger name="org.I0Itec.zkclient" level="WARN" />
+    <logger name="org.eclipse.jetty" level="WARN" />
+    <logger name="zookareg.core" level="WARN" />
+
+    <root level="INFO">
+        <appender-ref ref="CONSOLE"/>
+    </root>
+
+</configuration>

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject ovotech/kafka-clj-test-utils "0.2.0-1"
+(defproject ovotech/kafka-clj-test-utils "1.1.1-1"
   :description "Companion test utility library for `ovotech/kafka-clj-utils`"
   :url "https://github.com/ovotech/kafka-clj-test-utils"
   :license {:name "Eclipse Public License"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject ovotech/kafka-clj-test-utils "0.1.0-1"
+(defproject ovotech/kafka-clj-test-utils "0.2.0-1"
   :description "Companion test utility library for `ovotech/kafka-clj-utils`"
   :url "https://github.com/ovotech/kafka-clj-test-utils"
   :license {:name "Eclipse Public License"

--- a/project.clj
+++ b/project.clj
@@ -7,7 +7,7 @@
   :dependencies [[org.apache.kafka/kafka-clients "1.1.1" :exclusions [org.scala-lang/scala-library]]
                  [org.apache.kafka/kafka-streams "1.1.1"]
                  [org.clojure/clojure "1.9.0"]
-                 [ovotech/kafka-avro-confluent "0.10.0"]
+                 [ovotech/kafka-avro-confluent "0.11.0"]
                  [vise890/zookareg "1.1.1-1"]]
 
   :profiles {:dev {:resource-paths ["dev/resources" "test/resources"]

--- a/project.clj
+++ b/project.clj
@@ -5,7 +5,6 @@
             :url  "https://www.eclipse.org/legal/epl-v10.html"}
 
   :dependencies [[org.apache.kafka/kafka-clients "1.1.1" :exclusions [org.scala-lang/scala-library]]
-                 [org.apache.kafka/kafka-streams "1.1.1"]
                  [org.clojure/clojure "1.9.0"]
                  [ovotech/kafka-avro-confluent "0.11.0"]
                  [vise890/zookareg "1.1.1-1"]]

--- a/project.clj
+++ b/project.clj
@@ -4,11 +4,11 @@
   :license {:name "Eclipse Public License"
             :url  "https://www.eclipse.org/legal/epl-v10.html"}
 
-  :dependencies [[org.apache.kafka/kafka-clients "1.0.2" :exclusions [org.scala-lang/scala-library]]
-                 [org.apache.kafka/kafka-streams "1.0.2"]
+  :dependencies [[org.apache.kafka/kafka-clients "1.1.1" :exclusions [org.scala-lang/scala-library]]
+                 [org.apache.kafka/kafka-streams "1.1.1"]
                  [org.clojure/clojure "1.9.0"]
-                 [ovotech/kafka-avro-confluent "0.8.5"]
-                 [vise890/zookareg "1.0.2-1"]]
+                 [ovotech/kafka-avro-confluent "0.10.0"]
+                 [vise890/zookareg "1.1.1-1"]]
 
   :profiles {:dev {:resource-paths ["dev/resources" "test/resources"]
                    :dependencies [[ch.qos.logback/logback-classic "1.2.3"]

--- a/project.clj
+++ b/project.clj
@@ -10,7 +10,10 @@
                  [ovotech/kafka-avro-confluent "0.8.5"]
                  [vise890/zookareg "1.0.2-1"]]
 
-  :profiles {:ci  {:deploy-repositories
+  :profiles {:dev {:resource-paths ["dev/resources" "test/resources"]
+                   :dependencies [[ch.qos.logback/logback-classic "1.2.3"]
+                                  [ch.qos.logback/logback-core "1.2.3"]]}
+             :ci  {:deploy-repositories
                    [["clojars" {:url           "https://clojars.org/repo"
                                 :username      :env ;; LEIN_USERNAME
                                 :password      :env ;; LEIN_PASSWORD

--- a/src/kafka_clj_test_utils/consumer.clj
+++ b/src/kafka_clj_test_utils/consumer.clj
@@ -1,10 +1,10 @@
 (ns kafka-clj-test-utils.consumer
-  (:require [kafka-avro-confluent.deserializers :refer [->avro-deserializer]]
+  (:require [kafka-avro-confluent.v2.deserializer :as des]
             [kafka-clj-test-utils.core :as co])
-  (:import [java.util UUID]
-           [org.apache.kafka.clients.consumer KafkaConsumer]
+  (:import java.util.UUID
+           org.apache.kafka.clients.consumer.KafkaConsumer
            [org.apache.kafka.common PartitionInfo TopicPartition]
-           [org.apache.kafka.common.serialization StringDeserializer]))
+           org.apache.kafka.common.serialization.StringDeserializer))
 
 (defn- PartitionInfo->TopicPartition
   [^PartitionInfo pi]
@@ -14,7 +14,6 @@
   (->> k-consumer
        .subscription
        (mapcat #(.partitionsFor k-consumer %))))
-
 (defn- subscribed-TopicPartitions
   [^KafkaConsumer k-consumer]
   (->> k-consumer
@@ -33,35 +32,6 @@
 (defn subscribe [consumer & topics] (.subscribe consumer topics))
 (defn unsubscribe [consumer] (.unsubscribe consumer))
 
-(defn seek-to-end
-  [consumer]
-  (.poll consumer 0)
-  (.seekToEnd consumer [])
-  ;; NOTE we poll to force the seek, assuming it's ok to discard any messages on
-  ;; the topic when this is called
-  (.poll consumer 0))
-
-(defn seek-to-beginning
-  [consumer]
-  (.poll consumer 0)
-  ;; NOTE we don't poll here, as we don't wanna discard the messages
-  (.seekToBeginning consumer []))
-
-(defn with-consumer
-  ([kafka-config kafka-schema-registry-config f]
-   (let [cc (co/normalize-config (merge kafka-config
-                                        {:group.id (str "kafka-clj-test-utils-"
-                                                        (UUID/randomUUID))}))
-         key-deserializer (StringDeserializer.)
-         schema-registry (co/->schema-registry kafka-schema-registry-config)
-         value-deserializer (->avro-deserializer schema-registry)
-         k-consumer (KafkaConsumer. cc key-deserializer value-deserializer)]
-     (try (f k-consumer) (finally (.close k-consumer)))))
-  ([config f]
-    (let [kafka-config                 (:kafka-config config)
-          kafka-schema-registry-config (:kafka-clj-utils.schema-registry/client config)]
-      (with-consumer kafka-config kafka-schema-registry-config f))))
-
 (defn- ConsumerRecord->m
   [cr]
   (-> cr
@@ -72,7 +42,6 @@
                          :kafka/timestamp (.timestamp cr),
                          :kafka/key       (.key cr)}
                         (meta (.value cr))))))
-
 (defn committed-info
   [consumer]
   (->> (subscribed-TopicPartitions consumer)
@@ -80,6 +49,19 @@
               {:topic (.topic tp),
                :partition (.partition tp),
                :offset (.offset (.committed consumer tp))}))))
+
+(defn seek-to-end
+  [consumer]
+  (.poll consumer 0)
+  (.seekToEnd consumer [])
+  ;; NOTE we poll to force the seek, assuming it's ok to discard any messages on
+  ;; the topic when this is called
+  (.poll consumer 0))
+(defn seek-to-beginning
+  [consumer]
+  (.poll consumer 0)
+  ;; NOTE we don't poll here, as we don't wanna discard the messages
+  (.seekToBeginning consumer []))
 
 (defn poll*
   [consumer &
@@ -93,24 +75,35 @@
                      (map ConsumerRecord->m (.poll consumer poll-timeout)))
              (dec retries)))))
 
+(defn with-consumer
+  ([kafka-config kafka-serde-config f]
+   (let [cc                 (co/normalize-config (merge kafka-config
+                                                        {:group.id (str "kafka-clj-test-utils-"
+                                                                        (UUID/randomUUID))}))
+         key-deserializer   (StringDeserializer.)
+         value-deserializer (des/->avro-deserializer kafka-serde-config)
+         k-consumer         (KafkaConsumer. cc key-deserializer value-deserializer)]
+     (try (f k-consumer) (finally (.close k-consumer)))))
+  ([config f]
+   (with-consumer (:kafka/config config) (:kafka.serde/config config) f)))
+
 (defn consume
-  [config topic & args]
-  (with-consumer config
-                 (fn [consumer]
-                   (assign-partition-0 consumer topic)
-                   (seek-to-beginning consumer)
-                   (apply poll* consumer args))))
+  ([config topic & args]
+   (with-consumer config
+     (fn [consumer]
+       (assign-partition-0 consumer topic)
+       (seek-to-beginning consumer)
+       (apply poll* consumer args)))))
 
 (defn with-1-partition-consumer-from-end
-  [kafka-config kafka-schema-registry-config topic f]
-  (with-consumer kafka-config
-                 kafka-schema-registry-config
-                 (fn [kc]
-                   (assign-partition-0 kc topic)
-                   (seek-to-end kc)
-                   ;; NOTE seek is lazy, so we force a poll here
-                   ;; **YOU SHOULD CALL THIS BEFORE MESSAGES ARE PRODUCED, OR
-                   ;; THIS POLL
-                   ;; WILL CONSUME THEM**
-                   (.poll kc 1)
-                   (f kc))))
+  [kafka-config kafka-serde-config topic f]
+  (with-consumer kafka-config kafka-serde-config
+    (fn [kc]
+      (assign-partition-0 kc topic)
+      (seek-to-end kc)
+      ;; NOTE seek is lazy, so we force a poll here
+      ;; **YOU SHOULD CALL THIS BEFORE MESSAGES ARE PRODUCED, OR
+      ;; THIS POLL
+      ;; WILL CONSUME THEM**
+      (.poll kc 1)
+      (f kc))))

--- a/src/kafka_clj_test_utils/producer.clj
+++ b/src/kafka_clj_test_utils/producer.clj
@@ -1,37 +1,38 @@
 (ns kafka-clj-test-utils.producer
-  (:require [kafka-avro-confluent.serializers :refer [->avro-serializer]]
+  (:require [kafka-avro-confluent.v2.serializer :as ser]
             [kafka-clj-test-utils.core :as co])
-  (:import [java.util UUID]
-           [org.apache.kafka.clients.producer ProducerRecord KafkaProducer]
-           [org.apache.kafka.common.serialization StringSerializer]))
-
+  (:import java.util.UUID
+           [org.apache.kafka.clients.producer KafkaProducer ProducerRecord]
+           org.apache.kafka.common.serialization.StringSerializer))
 
 (defn with-producer
-  [kafka-config kafka-schema-registry-config schema f]
-  (let [pc (co/normalize-config (merge kafka-config
-                                    {:retries 3,
-                                     :acks "all",
-                                     :compression.type "gzip",
-                                     :max.request.size 5242880,
-                                     :request.timeout.ms 10000,
-                                     :max.block.ms 10000}))
-        key-serializer (StringSerializer.)
-        schema-registry (co/->schema-registry kafka-schema-registry-config)
-        value-serializer (->avro-serializer schema-registry schema)
-        k-producer (KafkaProducer. pc key-serializer value-serializer)]
-    (try (f k-producer) (finally (.close k-producer)))))
-
+  ([kafka-config kafka-serde-config f]
+   (let [pc               (co/normalize-config (merge kafka-config
+                                                      {:retries            3,
+                                                       :acks               "all",
+                                                       :compression.type   "gzip",
+                                                       :max.request.size   5242880,
+                                                       :request.timeout.ms 10000,
+                                                       :max.block.ms       10000}))
+         key-serializer   (StringSerializer.)
+         value-serializer (ser/->avro-serializer kafka-serde-config)
+         k-producer       (KafkaProducer. pc key-serializer value-serializer)]
+     (try (f k-producer) (finally (.close k-producer)))))
+  ([config f]
+   (with-producer (:kafka/config config) (:kafka.serde/config config) f)))
 
 (defn produce
-  ([kafka-config kafka-schema-registry-config topic schema val]
+  ([kafka-config kafka-serde-config topic schema val]
    (with-producer
      kafka-config
-     kafka-schema-registry-config
-     schema
+     kafka-serde-config
      (fn [p]
-       (deref (.send p (ProducerRecord. topic (str (UUID/randomUUID)) val)))
+       (deref (.send p (ProducerRecord. topic (str (UUID/randomUUID)) {:value val
+                                                                       :schema schema})))
        (.flush p))))
   ([config topic schema val]
-   (let [kafka-config                 (:kafka-config config)
-         kafka-schema-registry-config (:kafka-clj-utils.schema-registry/client config)]
-     (produce kafka-config kafka-schema-registry-config topic schema val))))
+   (produce (:kafka/config config)
+            (:kafka.serde/config config)
+            topic
+            schema
+            val)))

--- a/test/kafka_clj_test_utils/utils_test.clj
+++ b/test/kafka_clj_test_utils/utils_test.clj
@@ -24,39 +24,22 @@
     :else (with-around-fns (butlast around-fns)
                            (fn [] ((last around-fns) f)))))
 
-(defn with-ig-sys
-  [ig-config f]
-  (let [_       (ig/load-namespaces ig-config)
-        system  (ig/init ig-config)]
-    (try
-      (f)
-      (finally (ig/halt! system)))))
-
 (def topic-a "test.topic.a")
 (def topic-b "test.topic.b")
-(def ig-config {:kafka-clj-utils.schema-registry/client {:base-url "http://localhost:8081"}})
-(def config (assoc-in ig-config
-                      [:kafka-config :bootstrap.servers] "127.0.0.1:9092"))
+
+(def config {:kafka/config       {:bootstrap.servers "127.0.0.1:9092"}
+             :kafka.serde/config {:schema-registry/base-url "http://localhost:8081"}})
 
 
 (use-fixtures :each (partial with-around-fns [zkr/with-zookareg-fn
                                                  (partial co/with-topic topic-a)
-                                                 (partial co/with-topic topic-b)
-                                                 (partial with-ig-sys ig-config)]))
-
-
+                                                 (partial co/with-topic topic-b)]))
 
 (def test-schema
   {:namespace "kafkaCljTestUtils"
    :type      "record"
    :name      "TestRecord"
-   :fields    [#_{:name "metadata"
-                :type {:type   "record"
-                       :name   "metaV1"
-                       :fields [{:name "eventId" :type "string"}
-                                {:name "createdAt" :type "long" :logicalType "timestamp-millis"}
-                                {:name "traceToken" :type "string"}]}}
-               {:name "foo" :type "string"}
+   :fields    [{:name "foo" :type "string"}
                {:name "bar" :type "string"}]})
 
 (def event1 {:foo "FOO" :bar "BAR"})

--- a/test/kafka_clj_utils/schema_registry.clj
+++ b/test/kafka_clj_utils/schema_registry.clj
@@ -1,9 +1,0 @@
-(ns kafka-clj-utils.schema-registry
-  (:require [clojure.test :refer :all]
-            [kafka-avro-confluent.schema-registry-client :as schema-registry]
-            [integrant.core :as ig]))
-
-
-(defmethod ig/init-key ::client
-  [_ opts]
-  (schema-registry/->schema-registry-client opts))


### PR DESCRIPTION
.. so that we can update kafka-clj-utils, so that we can keep a producer around to produce messages with the same schema