### PR TITLE
Bump version to 2.1.0-4

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject ovotech/kafka-clj-test-utils "2.1.0-2"
+(defproject ovotech/kafka-clj-test-utils "2.1.0-4"
   :description "Companion test utility library for `ovotech/kafka-clj-utils`"
   :url "https://github.com/ovotech/kafka-clj-test-utils"
   :license {:name "Eclipse Public License"


### PR DESCRIPTION
Looks like we previously deployed a version 2.1.0-3 [here](https://github.com/ovotech/kafka-clj-test-utils/commit/941fadbf51b0784f5ca79966dc54d98f41eb6428,) so that version number is invalid now.